### PR TITLE
Corrected the name of pin 37 for the ATMEGA32U4 and ATMEGA32U4_QFN44 symbols

### DIFF
--- a/acheron_Symbols.kicad_sym
+++ b/acheron_Symbols.kicad_sym
@@ -772,7 +772,7 @@
         (number "36" (effects (font (size 0.9906 0.9906))))
       )
       (pin bidirectional line (at 12.7 40.64 270) (length 2.54)
-        (name "ADC5/PF5" (effects (font (size 0.9906 0.9906))))
+        (name "ADC6/PF6" (effects (font (size 0.9906 0.9906))))
         (number "37" (effects (font (size 0.9906 0.9906))))
       )
       (pin bidirectional line (at 6.35 40.64 270) (length 2.54)

--- a/acheron_Symbols.kicad_sym
+++ b/acheron_Symbols.kicad_sym
@@ -970,7 +970,7 @@
         (number "36" (effects (font (size 0.9906 0.9906))))
       )
       (pin bidirectional line (at 12.7 40.64 270) (length 2.54)
-        (name "ADC5/PF5" (effects (font (size 0.9906 0.9906))))
+        (name "ADC6/PF6" (effects (font (size 0.9906 0.9906))))
         (number "37" (effects (font (size 0.9906 0.9906))))
       )
       (pin bidirectional line (at 6.35 40.64 270) (length 2.54)


### PR DESCRIPTION
This PR fixes the issue described here https://github.com/AcheronProject/acheron_Symbols/issues/3.